### PR TITLE
Jwt passport strategy

### DIFF
--- a/auth/strategies.js
+++ b/auth/strategies.js
@@ -1,6 +1,8 @@
 const LocalStrategy = require('passport-local');
 const userController = require('../controllers/user')
 const _ = require('lodash')
+const passportJWT = require("passport-jwt");
+const ExtractJWT = passportJWT.ExtractJwt;
 
 const hash = function (password) {
     return password;
@@ -18,4 +20,21 @@ const localStrategy = new LocalStrategy(
     }
 )
 
-module.exports = { localStrategy } 
+const jwtStrategy = new passportJWT.Strategy({
+    jwtFromRequest: ExtractJWT.fromAuthHeaderAsBearerToken(),
+    secretOrKey: 'JWWWWWWTTTSECRET_FANTASY'
+},
+    function (jwtPayload, done) {
+        console.log("HIIIIIIIIIII")
+        return userController.findByUid(jwtPayload.uid, (err, user) => {
+            if (err) {
+                console.log(err)
+                return done(null, false)
+            } else {
+                return done(null, user)
+            }
+        })
+    }
+)
+
+module.exports = { localStrategy, jwtStrategy } 

--- a/auth/strategies.js
+++ b/auth/strategies.js
@@ -3,6 +3,8 @@ const userController = require('../controllers/user')
 const _ = require('lodash')
 const passportJWT = require("passport-jwt");
 const ExtractJWT = passportJWT.ExtractJwt;
+const JWT_SECRET_KEY = 'Jurong_west_secret_Tea'
+const {Roles} = require('../auth/')
 
 const hash = function (password) {
     return password;
@@ -20,14 +22,13 @@ const localStrategy = new LocalStrategy(
     }
 )
 
-const jwtStrategy = new passportJWT.Strategy({
+const jwtStrategyRider = new passportJWT.Strategy({
     jwtFromRequest: ExtractJWT.fromAuthHeaderAsBearerToken(),
-    secretOrKey: 'JWWWWWWTTTSECRET_FANTASY'
+    secretOrKey: JWT_SECRET_KEY,
 },
-    function (jwtPayload, done) {
-        console.log("HIIIIIIIIIII")
+    async function (jwtPayload, done) {
         return userController.findByUid(jwtPayload.uid, (err, user) => {
-            if (err) {
+            if (err || user.role != Roles.rider) {
                 console.log(err)
                 return done(null, false)
             } else {
@@ -37,4 +38,52 @@ const jwtStrategy = new passportJWT.Strategy({
     }
 )
 
-module.exports = { localStrategy, jwtStrategy } 
+const jwtStrategyCustomer = new passportJWT.Strategy({
+    jwtFromRequest: ExtractJWT.fromAuthHeaderAsBearerToken(),
+    secretOrKey: JWT_SECRET_KEY,
+},
+    async function (jwtPayload, done) {
+        return userController.findByUid(jwtPayload.uid, (err, user) => {
+            if (err || user.role != Roles.customer) {
+                console.log(err)
+                return done(null, false)
+            } else {
+                return done(null, user)
+            }
+        })
+    }
+)
+
+const jwtStrategyStaff = new passportJWT.Strategy({
+    jwtFromRequest: ExtractJWT.fromAuthHeaderAsBearerToken(),
+    secretOrKey: JWT_SECRET_KEY,
+},
+    async function (jwtPayload, done) {
+        return userController.findByUid(jwtPayload.uid, (err, user) => {
+            if (err || user.role != Roles.staff) {
+                console.log(err)
+                return done(null, false)
+            } else {
+                return done(null, user)
+            }
+        })
+    }
+)
+
+const jwtStrategyManager = new passportJWT.Strategy({
+    jwtFromRequest: ExtractJWT.fromAuthHeaderAsBearerToken(),
+    secretOrKey: JWT_SECRET_KEY,
+},
+    async function (jwtPayload, done) {
+        return userController.findByUid(jwtPayload.uid, (err, user) => {
+            if (err || user.role != Roles.manager) {
+                console.log(err)
+                return done(null, false)
+            } else {
+                return done(null, user)
+            }
+        })
+    }
+)
+
+module.exports = { localStrategy, jwtStrategyRider, jwtStrategyCustomer, jwtStrategyManager, jwtStrategyStaff, JWT_SECRET_KEY } 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const session = require("express-session");
 const bodyParser = require("body-parser");
 const logger = require('morgan');
 const strategies = require('./auth/strategies');
-const userController = require('./controllers/user')
 const passport = require('passport')
 const cors = require('cors');
 
@@ -24,16 +23,19 @@ app.use(passport.initialize());
 app.use(passport.session());
 
 passport.use('local', strategies.localStrategy);
-passport.use('jwt', strategies.jwtStrategy);
+passport.use('jwt-rider', strategies.jwtStrategyRider);
+passport.use('jwt-manager', strategies.jwtStrategyManager);
+passport.use('jwt-customer', strategies.jwtStrategyCustomer);
+passport.use('jwt-staff', strategies.jwtStrategyStaff);
 
 app.use(logger('tiny'));
 
 app.use('/login', loginRouter);
 app.use('/logout', logoutRouter);
-app.use('/customer', customerRouter);
-app.use('/rider', passport.authenticate('jwt', {session: false}),riderRouter);
-app.use('/staff', staffRouter);
-app.use('/manager', managerRouter);
+app.use('/customer', passport.authenticate('jwt-customer', {session: false}),customerRouter);
+app.use('/rider', passport.authenticate('jwt-rider', {session: false}),riderRouter);
+app.use('/staff', passport.authenticate('jwt-staff', {session: false}),staffRouter);
+app.use('/manager', passport.authenticate('jwt-manager', {session: false}),managerRouter);
 
 app.listen(port, () => {
     console.log(`Listening to requests on http://localhost:${port}`);

--- a/index.js
+++ b/index.js
@@ -23,23 +23,15 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(passport.initialize());
 app.use(passport.session());
 
-
-passport.serializeUser(function (user, done) {
-    done(null, user.uid);
-});
-
-passport.deserializeUser(function (uid, done) {
-    userController.findByUid(uid, (err, user) => done(err, user))
-});
-
 passport.use('local', strategies.localStrategy);
+passport.use('jwt', strategies.jwtStrategy);
 
 app.use(logger('tiny'));
 
 app.use('/login', loginRouter);
 app.use('/logout', logoutRouter);
 app.use('/customer', customerRouter);
-app.use('/rider', riderRouter);
+app.use('/rider', passport.authenticate('jwt', {session: false}),riderRouter);
 app.use('/staff', staffRouter);
 app.use('/manager', managerRouter);
 

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-session": "^1.17.0",
+    "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.15",
     "morgan": "^1.9.1",
     "passport": "^0.4.1",
+    "passport-jwt": "^4.0.0",
     "passport-local": "^1.0.0",
     "pg-promise": "^10.4.3"
   }

--- a/routes/customer.js
+++ b/routes/customer.js
@@ -1,8 +1,5 @@
 const express = require('express')
 const router = express.Router()
-const authMiddleWare = require('../auth')
-
-router.all("/", authMiddleWare.authorizeCustomer);
 
 router.get("/", (req, res) => res.send(`Hi I'm ${req.user.name}. I'm a ${req.user.role}.`))
 

--- a/routes/login.js
+++ b/routes/login.js
@@ -2,12 +2,14 @@ const express = require('express')
 const router = express.Router()
 const passport = require('passport')
 const _ = require('lodash')
+const jwt = require('jsonwebtoken');
 
 router.post('/',
-    passport.authenticate('local'),
+    passport.authenticate('local', {session: false}),
     async (req, res) => {
         const user = _.omit(req.user, ['password'])
-        res.send(user);
+        const token = jwt.sign(user, 'JWWWWWWTTTSECRET_FANTASY');
+        return res.json({user, token});
     }
 );
-module.exports = router;
+module.exports = router

--- a/routes/login.js
+++ b/routes/login.js
@@ -3,12 +3,13 @@ const router = express.Router()
 const passport = require('passport')
 const _ = require('lodash')
 const jwt = require('jsonwebtoken');
+const {JWT_SECRET_KEY} = require("../auth/strategies")
 
 router.post('/',
     passport.authenticate('local', {session: false}),
     async (req, res) => {
         const user = _.omit(req.user, ['password'])
-        const token = jwt.sign(user, 'JWWWWWWTTTSECRET_FANTASY');
+        const token = jwt.sign(user, JWT_SECRET_KEY);
         return res.json({user, token});
     }
 );

--- a/routes/login.js
+++ b/routes/login.js
@@ -8,8 +8,8 @@ const {JWT_SECRET_KEY} = require("../auth/strategies")
 router.post('/',
     passport.authenticate('local', {session: false}),
     async (req, res) => {
-        const user = _.omit(req.user, ['password'])
-        const token = jwt.sign(user, JWT_SECRET_KEY);
+        const user = _.omit(req.user, ['password', 'passwordhash', 'salt'])
+        const token = jwt.sign({uid: user.uid}, JWT_SECRET_KEY);
         return res.json({user, token});
     }
 );

--- a/routes/manager.js
+++ b/routes/manager.js
@@ -1,8 +1,5 @@
 var express = require('express');
 var router = express.Router();
-const authMiddleWare = require('../auth')
-
-router.all("/", authMiddleWare.authorizeManager);
 
 router.get("/", (req, res) => res.send(`Hi I'm ${req.user.name}. I'm a ${req.user.role}.`))
 

--- a/routes/rider.js
+++ b/routes/rider.js
@@ -1,8 +1,5 @@
 var express = require('express');
 var router = express.Router();
-const authMiddleWare = require('../auth')
-
-router.all("/", authMiddleWare.authorizeRider);
 
 router.get("/", (req, res) => res.send(`Hi I'm ${req.user.name}. I'm a ${req.user.role}.`))
 

--- a/routes/staff.js
+++ b/routes/staff.js
@@ -1,8 +1,5 @@
 var express = require('express');
 var router = express.Router();
-const authMiddleWare = require('../auth')
-
-router.all("/", authMiddleWare.authorizeStaff);
 
 router.get("/", (req, res) => res.send(`Hi I'm ${req.user.name}. I'm a ${req.user.role}.`))
 


### PR DESCRIPTION
Change user routes to use jwt token strategy
Login still uses local strategy to generate the desired jwt
jwt token from uid only
Next step: Frontend takes jwt token, use it for requests and saves it locally until logout