### PR TITLE
Add apis for different rider stats

### DIFF
--- a/controllers/orders.js
+++ b/controllers/orders.js
@@ -88,10 +88,10 @@ const psGetMonthlySalesSummary = new PS({ name: 'monthly-sales-summary',
     "HAVING date_part('month', deliveredtime) IS NOT NULL and date_part('year', deliveredtime) IS NOT NULL " +
     "ORDER BY year, month;"});
 
-const psGetMonthlyCustomerOrderSummary = new PS({name: 'customer-monthly-order-summary', text: "SELECT customerid, date_part('month', deliveredtime) as month, date_part('year', deliveredtime) as year, \n" +
+const psGetMonthlyCustomerOrderSummary = new PS({name: 'customer-monthly-order-summary', text: "SELECT customerid, name, date_part('month', deliveredtime) as month, date_part('year', deliveredtime) as year, \n" +
     "count(*) as order_count, sum(finalprice) as totalPrice\n" +
-    "FROM ORDERS \n" +
-    "GROUP BY month, year, customerid\n" +
+    "FROM ORDERS join Users on (customerid = uid)\n" +
+    "GROUP BY month, year, customerid, name\n" +
     "HAVING date_part('month', deliveredtime) IS NOT NULL and date_part('year', deliveredtime) IS NOT NULL " +
     "ORDER BY year, month;"});
 

--- a/controllers/rider.js
+++ b/controllers/rider.js
@@ -217,8 +217,8 @@ const psGetPTSalaryInfo = new PS({
 
 const psGetRiderRatingInfo = new PS({
     name:"rider-rating-info",
-    text: "SELECT uid, name, count(*), TRUNC(avg(value), 1) as avg_rating, date_part('year', date) as year, date_part('month', date) as month " +
-    "FROM ratings JOIN orders using(oid) JOIN riders on (riderid = uid) JOIN Users using(uid) " +
+    text: "SELECT uid, name, count(value), COALESCE(TRUNC(avg(value), 1), 0) as avg_rating, date_part('year', date) as year, date_part('month', date) as month " +
+    "FROM ratings JOIN orders using(oid) RIGHT JOIN riders on (riderid = uid) JOIN Users using(uid) " +
     "GROUP BY uid, name, year, month " +
     "ORDER BY uid, year, month;"
 });
@@ -237,7 +237,7 @@ const psGetRiderTotalOrdersAndAverageDeliveryTime = new PS({
                                         "date_part('month', deliveredtime) as month, riderid, " +
                                         "EXTRACT(EPOCH from deliveredtime - departfromr)/60 as deliverytime, deliveredtime, departfromr " +
                                         "FROM orders)\n" +
-    "SELECT riderid, name, month, year, avg(deliverytime) as average_mins, count(*) as total_orders_delivered " +
+    "SELECT riderid, name, month, year, round(CAST(avg(deliverytime) as numeric), 2) as average_mins, count(*) as total_orders_delivered " +
     "FROM Rider_Delivery_Time join Users on (riderid = uid) " +
     "GROUP BY riderid, name, year, month " +
     "HAVING year IS NOT NULL and month IS NOT NULL " +

--- a/controllers/rider.js
+++ b/controllers/rider.js
@@ -240,6 +240,7 @@ const psGetRiderTotalOrdersAndAverageDeliveryTime = new PS({
     "SELECT riderid, name, month, year, avg(deliverytime) as average_mins, count(*) as total_orders_delivered " +
     "FROM Rider_Delivery_Time join Users on (riderid = uid) " +
     "GROUP BY riderid, name, year, month " +
+    "HAVING year IS NOT NULL and month IS NOT NULL " +
     "ORDER BY riderid, year, month;"
 });
 

--- a/routes/manager/index.js
+++ b/routes/manager/index.js
@@ -1,7 +1,7 @@
 var router = require('express').Router();
 
-
 router.get("/", (req, res) => res.send(`Hi I'm ${req.user.name}. I'm a ${req.user.role}.`))
 
 router.use('/orders', require('./orders'));
+router.use('/rider', require('./rider'));
 module.exports = router;

--- a/routes/manager/rider.js
+++ b/routes/manager/rider.js
@@ -1,0 +1,36 @@
+var express = require('express');
+var router = express.Router();
+const {getRiderSalaryInfo, getRiderTotalOrdersAndAverageTime, getRiderRatingInfo} = require('../../controllers/rider');
+
+
+router.get('/salary-summary', async (req, res, next) => {
+    let result;
+try {
+    result = await getRiderSalaryInfo();
+} catch (err) {
+    return next(err)
+}
+return res.send(result);
+});
+
+router.get('/rating-summary', async (req, res, next) => {
+    let result;
+try {
+    result = await getRiderRatingInfo();
+} catch (err) {
+    return next(err)
+}
+return res.send(result);
+});
+
+router.get('/order-summary', async (req, res, next) => {
+    let result;
+try {
+    result = await getRiderTotalOrdersAndAverageTime();
+} catch (err) {
+    return next(err)
+}
+return res.send(result);
+});
+
+module.exports = router;


### PR DESCRIPTION
API for the following:

- for each rider and each month, rider # of ratings and average rating
- for each rider and each month, total salary and hours clocked
- for each rider and each month, total orders delivered and avg delivery time

Currently, the data has inaccuracies wrt to `deliveredtime`, as `deliveredtime < departfromr` in `Orders`

I'll make changes to the data and push 